### PR TITLE
Fixed issue with salmon quantmerge column argument not being read properly

### DIFF
--- a/Salmon/1.2.1/QuantMerge.nf
+++ b/Salmon/1.2.1/QuantMerge.nf
@@ -15,10 +15,10 @@ process QuantMerge {
     script:
         def quants = quant_dirs.collect{ "$it" }.join(",")
         """  
-        salmon quantmerge -c numreads --quants {${quants}} -o ${run_name}_transcripts_quantmerge_numReads.txt 
-        salmon quantmerge -c tpm --quants {${quants}} -o ${run_name}_transcripts_quantmerge_TPM.txt  
-        salmon quantmerge -c len --quants {${quants}} -o ${run_name}_transcripts_quantmerge_Length.txt
-        salmon quantmerge -c elen --quants {${quants}} -o ${run_name}_transcripts_quantmerge_EffectiveLength.txt
+        salmon quantmerge --column numreads --quants {${quants}} -o ${run_name}_transcripts_quantmerge_numReads.txt 
+        salmon quantmerge --column tpm --quants {${quants}} -o ${run_name}_transcripts_quantmerge_TPM.txt  
+        salmon quantmerge --column len --quants {${quants}} -o ${run_name}_transcripts_quantmerge_Length.txt
+        salmon quantmerge --column elen --quants {${quants}} -o ${run_name}_transcripts_quantmerge_EffectiveLength.txt
         """
 }
 


### PR DESCRIPTION
The salmon quantmerge argument "-c" does not seem to work properly on the salmon version that https://github.com/UMCUGenetics/RNASeq-NF uses and the latest version 1.4.0.
This causes the TPM(default) column to get merged 4 times instead of the 4 different columns.
Using "--column" instead resolves the issue.