### PR TITLE
Feature/workflow params log

### DIFF
--- a/Utils/workflow.nf
+++ b/Utils/workflow.nf
@@ -1,0 +1,15 @@
+process export_params {
+    tag {"Workflow Export Params ${sample_id}"}
+    label 'Workflow_Export_Params'
+    shell = ['/bin/bash', '-euo', 'pipefail']
+
+    output:
+        path("workflow_params.txt", emit: log)
+
+    script:
+        def workflow_params = params.collect{param -> "$param.key\t$param.value"}.join("\n")
+        """
+        echo -e "param\tvalue"
+        echo -e "${workflow_params}"
+        """
+}

--- a/Utils/workflow.nf
+++ b/Utils/workflow.nf
@@ -1,5 +1,5 @@
 process ExportParams {
-    tag {"Workflow Export Params ${sample_id}"}
+    tag {"Workflow Export Params"}
     label 'Workflow_Export_Params'
     shell = ['/bin/bash', '-euo', 'pipefail']
 

--- a/Utils/workflow.nf
+++ b/Utils/workflow.nf
@@ -1,4 +1,4 @@
-process export_params {
+process ExportParams {
     tag {"Workflow Export Params ${sample_id}"}
     label 'Workflow_Export_Params'
     shell = ['/bin/bash', '-euo', 'pipefail']

--- a/Utils/workflow.nf
+++ b/Utils/workflow.nf
@@ -4,12 +4,12 @@ process ExportParams {
     shell = ['/bin/bash', '-euo', 'pipefail']
 
     output:
-        path("workflow_params.txt", emit: log)
+        path("workflow_params.txt")
 
     script:
         def workflow_params = params.collect{param -> "$param.key\t$param.value"}.join("\n")
         """
-        echo -e "param\tvalue"
-        echo -e "${workflow_params}"
+        echo -e "param\tvalue" > workflow_params.txt
+        echo -e "${workflow_params}" >> workflow_params.txt
         """
 }

--- a/Utils/workflow.nf
+++ b/Utils/workflow.nf
@@ -7,7 +7,7 @@ process ExportParams {
         path("workflow_params.txt")
 
     script:
-        def workflow_params = params.collect{param -> "$param.key\t$param.value"}.join("\n")
+        def workflow_params = params.collect{param -> "$param.key\t$param.value"}.sort().join("\n")
         """
         echo -e "param\tvalue" > workflow_params.txt
         echo -e "${workflow_params}" >> workflow_params.txt

--- a/Utils/workflow.nf
+++ b/Utils/workflow.nf
@@ -2,6 +2,7 @@ process ExportParams {
     tag {"Workflow Export Params"}
     label 'Workflow_Export_Params'
     shell = ['/bin/bash', '-euo', 'pipefail']
+    cache = false  //Disable cache to force a new export when restarting the workflow.
 
     output:
         path("workflow_params.txt")


### PR DESCRIPTION
Process to export all workflow params in a tab delimited file. 

Example output:
```
param	value
dxtracks_path	/hpc/diaggen/software/production/Dx_tracks
fastq_path	/hpc/diaggen/data/upload/RAW_data_MIPS/nextseq_umc02/211013_NB501039_0388_AH3VN5AFX3
fingerprint_target	fingerprint/81SNP_design.vcf
gatk_path	/hpc/local/CentOS7/cog_bioinf/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef/GenomeAnalysisTK.jar
genome	/hpc/diaggen/data/databases/ref_genomes/Homo_sapiens.GRCh37.GATK.illumina/Homo_sapiens.GRCh37.GATK.illumina.fasta
mips_design_file	fingerprint/81_snp_mips_design.txt
mips_trim_dedup_path	/hpc/diaggen/software/production/mips
mips_uuid_length	8
mips_uuid_read	R1
outdir	/hpc/diaggen/projects/nextflow_params_log/211013_NB501039_0388_AH3VN5AFX3
```